### PR TITLE
Fix json elelement serialization

### DIFF
--- a/auto-value-gson-runtime/src/main/resources/META-INF/proguard/autovaluegson.pro
+++ b/auto-value-gson-runtime/src/main/resources/META-INF/proguard/autovaluegson.pro
@@ -1,3 +1,9 @@
+# modified by mapbox
 # Annotations are for embedding static analysis information.
 -dontwarn org.jetbrains.annotations.**
 -dontwarn com.google.errorprone.annotations.**
+
+-keepclassmembers class com.mapbox.auto.value.gson.SerializableJsonElement {
+    private void writeObject(java.io.ObjectOutputStream);
+    private void readObject(java.io.ObjectInputStream);
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 // modified by mapbox
 GROUP=com.mapbox.mapboxsdk
-VERSION_NAME=0.0.1
+VERSION_NAME=0.0.2-SNAPSHOT
 
 POM_DESCRIPTION=Mapbox fork of an AutoValue extension that creates a Gson TypeAdapter for JSON serialization of AutoValue classes.
 


### PR DESCRIPTION
R8 breaks custom serialization of `SerializableJsonElement`